### PR TITLE
Create environment automatically again

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -11,27 +11,15 @@ jobs:
   notify:
     name: Notify about deployment
     runs-on: ubuntu-latest
-    steps:
-      - name: Create deployment
-        id: deployment
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN_MANAGE_ENVS }}
-        run: |
-          ref=$(gh pr view ${{ github.event.inputs.issue }} --json headRefOid -q .headRefOid)
-          env=staging-${{ github.event.inputs.issue }}
-          url=https://$env.cmbuckley.co.uk
-          echo "url=$url" >> $GITHUB_OUTPUT
+    environment:
+      name: staging-${{ github.event.inputs.issue }}
+      url: ${{ steps.get-url.outputs.url }}
 
-          # create environment, deployment and success status
-          gh api -X PUT repos/{owner}/{repo}/environments/$env
-          deployment=$(gh api repos/{owner}/{repo}/deployments \
-            -f ref=$ref \
-            -f environment=$env \
-            -F required_contexts[]=netlify/{owner}/deploy-preview -q .id)
-          gh api -X POST repos/{owner}/{repo}/deployments/$deployment/statuses \
-            -f state=success \
-            -f environment_url=$url
+    steps:
+      - name: Get deployment URL
+        id: get-url
+        run: |
+          echo "url=https://staging-${{ github.event.inputs.issue }}.cmbuckley.co.uk" >> $GITHUB_OUTPUT
 
       - name: Find Comment
         uses: peter-evans/find-comment@v3
@@ -50,7 +38,7 @@ jobs:
           body: |
             ### <span aria-hidden="true">✅</span> Deploy Preview ready!
 
-            |      Name      | Link                                |
-            |----------------|-------------------------------------|
-            | Deploy Preview | ${{ steps.deployment.outputs.url }} |
-            | Deploy Log     | ${{ github.event.inputs.log }}      |
+            |      Name      | Link                             |
+            |----------------|----------------------------------|
+            | Deploy Preview | ${{ steps.get-url.outputs.url }} |
+            | Deploy Log     | ${{ github.event.inputs.log }}   |

--- a/_cf/netlify-deployment-status/index.js
+++ b/_cf/netlify-deployment-status/index.js
@@ -102,7 +102,7 @@ async function handleRequest(request) {
     }
 
     if (!payload.review_id) { return error("Missing PR number") }
-    console.log('Dispatching to ' + apiUrl + ' with issue ' + payload.review_id);
+    console.log(`Dispatching to ${apiUrl} with ref ${ref} and issue ${payload.review_id}`);
 
     try {
       workflowDispatch = await fetch(apiUrl + 'actions/workflows/deploy-preview.yml/dispatches', {

--- a/_cf/netlify-deployment-status/index.js
+++ b/_cf/netlify-deployment-status/index.js
@@ -125,7 +125,7 @@ async function handleRequest(request) {
         return error(err)
     }
 
-    console.log('GitHub response:', workflowDispatch)
+    console.log('GitHub response:', workflowDispatch.body)
     return new Response(workflowDispatch.body, {
       status: (workflowDispatch.ok ? 200 : 503),
       headers: workflowDispatch.headers,


### PR DESCRIPTION
Test that the `workflow_dispatch` event will create a deployment against the branch that received the event. This means the manual steps can be removed. This relies on Netlify using the commit ref in the dispatch, but the field isn't available so we grab it from the API in the Cloudflare worker.

See
https://answers.netlify.com/t/deploy-notification-payload-missing-commit-ref/155594